### PR TITLE
Feature/snippet style sheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Abaixo segue a lista com todos os Snippets disponíveis e os gatilhos para cada 
 |               `rnrsc →` | Cria um Componente **Stateless** conectado ao **Redux**                       |
 |                `rnfc →` | Cria um Componente **Functional**                                             |
 |           `styled-rn →` | Cria um arquivo de Estilização com **Styled Components**                      |
+|              `ssheet →` | Cria um arquivo de Estilização com **StyleSheet**                             |
 |                 `api →` | Cria um arquivo de configuração do Axios                                      |
 |     `mapstatetoprops →` | Cria o método `mapStateToProps` vazio                                         |
 |  `mapdispatchtoprops →` | Cria o método `mapDispatchToProps` vazio                                      |

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -317,5 +317,20 @@
       ""
     ],
     "description": "Create React Native Reactotron Config with Redux and Redux Saga"
+  },
+
+  "styleSheet": {
+    "prefix": "ssheet",
+    "body": [
+      "import { StyleSheet } from 'react-native';",
+      "",
+      "const styles = StyleSheet.create({",
+      "	$1",
+      "});",
+      "",
+      "export default styles;",
+      ""
+    ],
+    "description": "Create React Native StyleSheet file"
   }
 }


### PR DESCRIPTION
Olá, tudo bem?

Na aula de Estilos Globais do Módulo 2. APP 01 - Githuber (Bootcamp) o @diego3g usa um script que não está na extensão da Rocketseat para criar um arquivo de estilização usando StyleSheet. 

Criei na minha máquina local, e achei interessante compartilhar.

executando o gatilho: `ssheet`. Vai ser criado o arquivo de estilização:

``` 
import { StyleSheet } from 'react-native';

const styles = StyleSheet.create({
  // cursor do mouse vai ficar aqui
});

export default styles;
```